### PR TITLE
Support uppercase `BEGIN_SRC'

### DIFF
--- a/corg.el
+++ b/corg.el
@@ -45,7 +45,7 @@
 See `corg' for detailed documentation."
   (-let ((bounds (bounds-of-thing-at-point 'filename))
          (candidates (corg)))
-    (if candidates
+    (when candidates
       (list
        (or (car bounds) (point))
        (or (cdr bounds) (point))

--- a/corg.el
+++ b/corg.el
@@ -100,7 +100,7 @@ Generally speaking, returned completions are annotated with one of these:
            (s-match "^#\\+begin\\(:\\|_[a-zA-Z0-9]+\\) *\\([A-Za-z0-9_-]+\\)?* *\\(.*\\)?$" line))
           (block-type (pcase (s-chop-prefix "_" type)
                         (":" 'dblock)
-                        ("src" 'src))))
+                        ((or "src" "SRC") 'src))))
     (cond
      ((or (not line) (s-blank? type)) '())
      ((or (s-blank? what) (looking-back (format " %s" what) (line-beginning-position)))

--- a/corg.el
+++ b/corg.el
@@ -45,22 +45,23 @@
 See `corg' for detailed documentation."
   (-let ((bounds (bounds-of-thing-at-point 'filename))
          (candidates (corg)))
-    (list
-     (or (car bounds) (point))
-     (or (cdr bounds) (point))
-     (mapcar #'car candidates)
-     :annotation-function
-     (lambda (candidate)
-       (concat " " (plist-get (alist-get candidate candidates nil nil #'equal) :ann)))
-     :company-doc-buffer
-     (lambda (candidate)
-       (with-current-buffer (get-buffer-create " *corg*")
-         (erase-buffer)
-         (let ((doc (plist-get (alist-get candidate candidates nil nil #'equal) :doc)))
-           (insert (if (functionp doc)
-                       (funcall doc)
-                     doc)))
-         (current-buffer))))))
+    (if candidates
+      (list
+       (or (car bounds) (point))
+       (or (cdr bounds) (point))
+       (mapcar #'car candidates)
+       :annotation-function
+       (lambda (candidate)
+	 (concat " " (plist-get (alist-get candidate candidates nil nil #'equal) :ann)))
+       :company-doc-buffer
+       (lambda (candidate)
+	 (with-current-buffer (get-buffer-create " *corg*")
+           (erase-buffer)
+           (let ((doc (plist-get (alist-get candidate candidates nil nil #'equal) :doc)))
+             (insert (if (functionp doc)
+			 (funcall doc)
+                       doc)))
+           (current-buffer)))))))
 
 (defun corg ()
   "Return a list of possible completion candidates and their types.


### PR DESCRIPTION
Since org mode structure is case-insensitive, block-type should also match "SRC".