### PR TITLE
Make sure `block-type' is non-nil

### DIFF
--- a/corg.el
+++ b/corg.el
@@ -104,7 +104,9 @@ Generally speaking, returned completions are annotated with one of these:
                         ((or "src" "SRC") 'src))))
     (cond
      ((or (not line) (s-blank? type)) '())
-     ((or (s-blank? what) (looking-back (format " %s" what) (line-beginning-position)))
+     ((and block-type
+           (or (s-blank? what)
+               (looking-back (format " %s" what) (line-beginning-position))))
       (corg--block-types block-type))
      ((looking-back ":[a-zA-Z0-9_-]+ +\"?" (line-beginning-position))
       (-let* (((start end) (match-data))


### PR DESCRIPTION
This change ensures `block-type` is non-nil before before calling `corg--block-types`

-------

I was having an issue where I would ask for completions without any text around the cursor, such as:

```
#+title: Newfile
#+date: 2024-10-05

#+begin_quote |
```

and it would cause a `(wrong-type-argument stringp nil)` error.

<details><summary>Back trace:</summary>
<p>

Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  (string-prefix-p nil "")
  (and (fboundp symbol) (string-prefix-p prefix (symbol-name symbol)))
  (if (and (fboundp symbol) (string-prefix-p prefix (symbol-name symbol))) (progn (setq result (cons symbol result))))
  (#f(lambda (symbol) [(result nil) (prefix nil)] (if (and (fboundp symbol) (string-prefix-p prefix (symbol-name symbol))) (progn (setq result (cons symbol result))))) ##)
  (mapatoms #f(lambda (symbol) [(result nil) (prefix nil)] (if (and (fboundp symbol) (string-prefix-p prefix (symbol-name symbol))) (progn (setq result (cons symbol result))))))
  (let ((result 'nil)) (mapatoms #'(lambda (symbol) (if (and (fboundp symbol) (string-prefix-p prefix (symbol-name symbol))) (progn (setq result (cons symbol result)))))) result)
  (corg--get-functions-starting-with nil)
  (mapcar #'(lambda (it) (ignore it) (let ((lang (s-chop-prefixes '... (symbol-name it)))) (cons lang (list :ann (concat (symbol-name block-type) " type") :doc (corg--doc-fn lang block-type))))) (corg--get-functions-starting-with (cond ((eq block-type 'dblock) (let nil "org-dblock-write:")) ((eq block-type 'src) (let nil "org-babel-execute:")))))
  (corg--block-types nil)
  (cond ((or (not line) (s-blank? type)) 'nil) ((or (s-blank? what) (looking-back (format " %s" what) (line-beginning-position))) (corg--block-types block-type)) ((looking-back ":[a-zA-Z0-9_-]+ +\"?" (line-beginning-position)) (let* ((--dash-source-2-- (match-data)) (start (car-safe (prog1 --dash-source-2-- (setq --dash-source-2-- ...)))) (end (car --dash-source-2--)) (parameter (s-trim (s-chop-suffix "\"" (s-trim ...))))) (corg--parameter-types what block-type parameter))) ((not (s-blank? what)) (corg--parameters what block-type)) (t 'nil))
  (let* ((line (thing-at-point 'line t)) (--dash-source-1-- (cdr (s-match "^#\\+begin\\(:\\|_[a-zA-Z0-9]+\\) *\\([A-Za-z0-9_-]+\\)?* *\\(.*\\)?$" line))) (type (car-safe (prog1 --dash-source-1-- (setq --dash-source-1-- (cdr --dash-source-1--))))) (what (car-safe (prog1 --dash-source-1-- (setq --dash-source-1-- (cdr --dash-source-1--))))) (_params (car --dash-source-1--)) (block-type (let* ((val (s-chop-prefix "_" type))) (cond ((equal val '":") (let nil 'dblock)) ((member val '...) (let nil 'src)))))) (cond ((or (not line) (s-blank? type)) 'nil) ((or (s-blank? what) (looking-back (format " %s" what) (line-beginning-position))) (corg--block-types block-type)) ((looking-back ":[a-zA-Z0-9_-]+ +\"?" (line-beginning-position)) (let* ((--dash-source-2-- (match-data)) (start (car-safe (prog1 --dash-source-2-- ...))) (end (car --dash-source-2--)) (parameter (s-trim (s-chop-suffix "\"" ...)))) (corg--parameter-types what block-type parameter))) ((not (s-blank? what)) (corg--parameters what block-type)) (t 'nil)))
  (corg)
  (let ((input0 (bounds-of-thing-at-point 'filename)) (input1 (corg))) (let* ((bounds input0) (candidates input1)) (if candidates (progn (list (or (car bounds) (point)) (or (cdr bounds) (point)) (mapcar #'car candidates) :annotation-function #'(lambda (candidate) (concat " " ...)) :company-doc-buffer #'(lambda (candidate) (save-current-buffer ... ... ... ...)))))))
  (corg-completion-at-point)
  (corfu--capf-wrapper corg-completion-at-point t)
  (corfu--capf-wrapper-advice #<subr completion--capf-wrapper> corg-completion-at-point all)
  (apply corfu--capf-wrapper-advice #<subr completion--capf-wrapper> (corg-completion-at-point all))
  (#f(advice corfu--capf-wrapper-advice :around #<subr completion--capf-wrapper>) corg-completion-at-point all)
  (apply #f(advice corfu--capf-wrapper-advice :around #<subr completion--capf-wrapper>) (corg-completion-at-point all))
  (completion--capf-wrapper corg-completion-at-point all)
  (completion-at-point)
  (funcall-interactively completion-at-point)
  (command-execute completion-at-point)


</p>
</details> 