### PR TITLE
Support org-adapt-indentation set to t

### DIFF
--- a/corg.el
+++ b/corg.el
@@ -98,7 +98,7 @@ Generally speaking, returned completions are annotated with one of these:
           a definitely implemented, trusted completion."
   (-let* ((line (thing-at-point 'line t))
           ((_ type what _params)
-           (s-match "^#\\+begin\\(:\\|_[a-zA-Z0-9]+\\) *\\([A-Za-z0-9_-]+\\)?* *\\(.*\\)?$" line))
+           (s-match "^\s*#\\+begin\\(:\\|_[a-zA-Z0-9]+\\) *\\([A-Za-z0-9_-]+\\)?* *\\(.*\\)?$" line))
           (block-type (pcase (s-chop-prefix "_" type)
                         (":" 'dblock)
                         ((or "src" "SRC") 'src)


### PR DESCRIPTION
In case `org-adapt-indentation` is set to `t` the text of an org node is indented according to the depth of the headline of that node.

The regex checking if we are on a source code block line currently assumes that the start of the code block is always at the start of the line, not taking into account that a user might have `org-adapt-indentation` enabled. Allowing optional spaces before the `#begin` allows completions via `corg` in such setups.